### PR TITLE
Attempt to fix mic

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -480,7 +480,7 @@
 				</data>
 				<key>layout-id</key>
 				<data>
-				CwAAAA==
+				NgAAAA==
 				</data>
 			</dict>
 			<key>PciRoot(0x0)/Pci(0x2,0x0)</key>


### PR DESCRIPTION
I have the Dell Vostro 14 5481, that has the same 3204/236 ALC.
I have tried probably every possible layout ID, and with most of them the mic did not work. alcid=54 is the optimal one for 3204, as both speakers, 3.5mm jack (with headsets as well) and internal mic are all working.
On the other hand, I don't get why the device ID spoofing is necessary - it works flawlessly without it on my device, and does not work at all with it; maybe it is a 5490 thing, I don't really know. 